### PR TITLE
Fix ids mismatch vs gallery

### DIFF
--- a/run_reid_pipeline.py
+++ b/run_reid_pipeline.py
@@ -100,7 +100,7 @@ def load_gallery_feat_vectors(imgs_dir, attribute_extractor):
     if not os.path.exists(imgs_dir):
         raise ValueError("path doesn't exist")
     feat_vectors = list()
-    for name in os.listdir(imgs_dir):
+    for name in sorted(os.listdir(imgs_dir)):
         feat_vector = read_img_and_compute_feat_vector(
             os.path.join(imgs_dir, name), attribute_extractor)
         feat_vectors.append(feat_vector)


### PR DESCRIPTION
## Description

This fixes the bug manifesting as a mismatch between the `reid id` and the gallery `id` causing the ids shown on the videos to mismatch the true ids of the person as identified in the gallery.

## Type of change

Ensures files are read in sorted order of their name from the gallery (The file name correspond to the person's id).

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?


- [x] Ran the pipeline and compared gallery ids to the ids on the video


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

